### PR TITLE
PHP5 Install updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Usage: osf-install [OPTIONS]
 
 General Options:
 -h, --help                              Show this help section
--v, --verbose                           Make this insaller verbose
+-v, --verbose                           Make this installer verbose
 -c, --configure-installer               Configure the options used by this installer
 --list-configurations                   List the current configuration used by the installer tool
 

--- a/inc/OSFInstaller_Ubuntu_14_04.php
+++ b/inc/OSFInstaller_Ubuntu_14_04.php
@@ -42,10 +42,12 @@
       $this->exec('dpkg -i php5-common_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
       $this->exec('dpkg -i php5-cgi_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
       $this->exec('dpkg -i php5-cli_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
+      $this->exec('dpkg -i php5-readline_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
       $this->exec('dpkg -i php5-curl_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
       $this->exec('dpkg -i libapache2-mod-php5_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
       $this->exec('dpkg -i php5-mysql_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
       $this->exec('dpkg -i php5_5.5.9+dfsg-1ubuntu4.3_all.deb');
+      $this->exec('dpkg -i php-pear_5.5.9+dfsg-1ubuntu4.3_all.deb');
       $this->exec('dpkg -i php5-gd_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
       passthru('dpkg -i php5-odbc_5.5.9+dfsg-1ubuntu4.3_amd64.deb');
       
@@ -53,16 +55,18 @@
       $this->exec('apt-mark hold php5-common');
       $this->exec('apt-mark hold php5-cgi');
       $this->exec('apt-mark hold php5-cli');
+      $this->exec('apt-mark hold php5-readline');
       $this->exec('apt-mark hold php5-curl');
       $this->exec('apt-mark hold libapache2-mod-php5');
       $this->exec('apt-mark hold php5-mysql');
       $this->exec('apt-mark hold php5-odbc');
       $this->exec('apt-mark hold php5-gd');
+      $this->exec('apt-mark hold php-pear');
       $this->exec('apt-mark hold php5');
       
       // Modify /var/lib/dpkg/status such that php5-odbc is not marked as
       // dependent on libiodbc2. Otherwise it will always complain
-      // and we will have to be resolved in order to install anything else.
+      // and will have to be resolved in order to install anything else.
       $status = file_get_contents('/var/lib/dpkg/status');
       $status = str_replace('Depends: libc6 (>= 2.14), libiodbc2 (>= 3.52.7), phpapi-20121212, php5-common (= 5.5.9+dfsg-1ubuntu4.3), ucf',
                             'Depends: libc6 (>= 2.14), phpapi-20121212, php5-common (= 5.5.9+dfsg-1ubuntu4.3), ucf',


### PR DESCRIPTION
Dependencies in the Php5 packages required specific install and hold requests.
Copyedit in README.md.
