### PR TITLE
Support Linux Mint 17 (Ubuntu 14.04 based) in the install script.

### DIFF
--- a/inc/OSFInstaller_Ubuntu_14_04.php
+++ b/inc/OSFInstaller_Ubuntu_14_04.php
@@ -600,12 +600,26 @@
 
       foreach($output as $line)
       {
-        if(strpos($line, 'ubuntu') != -1)
+        if(strpos($line, 'ubuntu') !== FALSE)
         {
           // Validate version
           $version = (float) shell_exec('lsb_release -rs');
           
           if($version >= 14.04 && $version < 14.05)
+          {
+            return(TRUE);
+          }
+          else
+          {
+            return(FALSE);
+          }
+        }
+        elseif(strpos($line, 'Linux Mint') !== FALSE)
+        {
+          // Validate version
+          $version = (float) shell_exec('lsb_release -rs');
+
+          if($version >= 17 && $version < 18)
           {
             return(TRUE);
           }


### PR DESCRIPTION
Hello,

I'm running on Linux Mint 17.1 which is based on Ubuntu 14.04 (see http://www.linuxmint.com/rel_qiana_cinnamon_whatsnew.php#components) and got the following error when trying to install OSF for Drupal (using ./osf-installer --install-osf-drupal):

```
Option not supported for this Linux distribution and version.
```

After this patch I was able to finish the install on my local.
Also I think the strpos check needs to be like this: !== FALSE

Thank you,
Hervé
